### PR TITLE
feat: add configureCodeReader method to the Cube-App-SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,55 @@ await cube.restartOperatingSystem();
 await cube.restartUserInterface();
 ```
 
+### Configuring the code reader
+
+Push a standardized configuration to the connected code reader(s) — symbologies, indicators,
+trigger & timing, and output formatting. The config may be partial: the driver overlays it on its
+default profile and applies what the reader supports, silently skipping unsupported properties.
+
+```typescript
+import {Symbology} from "@variocube/cube-app-sdk";
+
+await cube.configureCodeReader({
+	symbologies: {
+		[Symbology.QR]: true,
+		[Symbology.Code128]: true,
+		[Symbology.EAN13]: false,
+	},
+	indicators: {
+		beeper: {enabled: true, volume: 80}, // volume/brightness are percentages, 0–100
+		led: {enabled: true, brightness: 50},
+	},
+	outputFormatting: {
+		terminator: "CRLF",
+	},
+});
+```
+
+The config is validated before it is sent. If it is invalid, `configureCodeReader` throws
+synchronously and nothing is sent:
+
+```typescript
+try {
+	await cube.configureCodeReader({indicators: {beeper: {volume: 150}}});
+}
+catch (error) {
+	// Error: Invalid code reader configuration: indicators.beeper.volume must be between 0 and 100
+}
+```
+
+You can run the same validation yourself, e.g. to give feedback in a settings UI before sending:
+
+```typescript
+import {validateCodeReaderConfig} from "@variocube/cube-app-sdk";
+
+const {valid, errors} = validateCodeReaderConfig(config);
+```
+
+> The config is applied to all connected code readers; there is no per-device targeting. In v1 the
+> driver only logs which properties it applied, skipped, or failed — no structured success/failure
+> result is returned to the app yet.
+
 ## Handling error conditions
 
 ### No connection to cube app service

--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,9 +3865,9 @@
       "link": true
     },
     "node_modules/@variocube/driver-common": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@variocube/driver-common/-/driver-common-2.7.1.tgz",
-      "integrity": "sha512-MZE+oycC545SMGZ86gC/mExdAFeoxcx/MsCIeWiYatiMDYBXOTyB4CpBpQWn8DEdX4kooo1EH5TsjWAmuA6y+w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@variocube/driver-common/-/driver-common-2.8.0.tgz",
+      "integrity": "sha512-AvoFHLots/RG0ujv4Tc04t4ocgkuYkE0vw7HHLmpluGDLWq6pGjDrw1mOfMRMfqlj+aw4nbyOfqF4pZucUMETA==",
       "license": "ISC",
       "dependencies": {
         "@variocube/vcmp": "^2.4.3 || ^3.0.0",
@@ -10959,7 +10959,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@variocube/driver-common": "^2.7.1",
+        "@variocube/driver-common": "^2.8.0",
         "@variocube/vcmp": "^2.3.0"
       }
     },
@@ -10972,7 +10972,7 @@
       },
       "devDependencies": {
         "@variocube/cube-app-mock": "^1.1.0",
-        "@variocube/driver-common": "^2.7.1",
+        "@variocube/driver-common": "^2.8.0",
         "@variocube/vcmp-server": "^2.4.0",
         "dotenv": "^16.5.0",
         "yargs": "^17.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,22 +3865,26 @@
       "link": true
     },
     "node_modules/@variocube/driver-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@variocube/driver-common/-/driver-common-2.2.0.tgz",
-      "integrity": "sha512-mF8X26Oep5rD6t/ULbJKzmojEXq3Bik2fVJKIndeGWoxmK5bbxVIjbDUrHkMRqeNSBMXspwRQy8T8ofurHzrhQ==",
-      "dev": true,
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@variocube/driver-common/-/driver-common-2.7.1.tgz",
+      "integrity": "sha512-MZE+oycC545SMGZ86gC/mExdAFeoxcx/MsCIeWiYatiMDYBXOTyB4CpBpQWn8DEdX4kooo1EH5TsjWAmuA6y+w==",
       "license": "ISC",
       "dependencies": {
-        "@variocube/vcmp": "^2.3.0",
+        "@variocube/vcmp": "^2.4.3 || ^3.0.0",
         "chalk": "^4.1.2",
-        "ws": "^8.17.1"
+        "ws": "^8.20.1"
       }
+    },
+    "node_modules/@variocube/driver-common/node_modules/@variocube/vcmp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@variocube/vcmp/-/vcmp-3.0.0.tgz",
+      "integrity": "sha512-4AHZ5Gw0UzDod724tsfJ6RPQ66fsJ1qkz8ydr9R59c+tWtj4OCRQzCc9KONr4b5UNKNwVCXPniuOhJKr0IG/0g==",
+      "license": "MIT"
     },
     "node_modules/@variocube/driver-common/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3897,7 +3901,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4229,7 +4232,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4834,7 +4836,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4847,7 +4848,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -6262,7 +6262,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10822,10 +10821,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10961,6 +10959,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@variocube/driver-common": "^2.7.1",
         "@variocube/vcmp": "^2.3.0"
       }
     },
@@ -10973,7 +10972,7 @@
       },
       "devDependencies": {
         "@variocube/cube-app-mock": "^1.1.0",
-        "@variocube/driver-common": "^2.2.0",
+        "@variocube/driver-common": "^2.7.1",
         "@variocube/vcmp-server": "^2.4.0",
         "dotenv": "^16.5.0",
         "yargs": "^17.7.2"

--- a/packages/cube-app-mock/src/main.tsx
+++ b/packages/cube-app-mock/src/main.tsx
@@ -5,6 +5,7 @@ import {
 	CodeMessage,
 	Compartment,
 	CompartmentsMessage,
+	ConfigureCodeReaderMessage,
 	Device,
 	DevicesMessage,
 	LockMessage,
@@ -108,6 +109,11 @@ function App() {
 		client.on<RestartDeviceMessage>("restartDevice", ({deviceId}) => {
 			setRestarting(`Restarting device ${deviceId}...`);
 			setTimeout(() => setRestarting(undefined), 5000);
+		});
+		client.on<ConfigureCodeReaderMessage>("configureCodeReader", ({config}) => {
+			// The mock has no real reader to configure; log the received config like the
+			// driver does in v1 so the pass-through is observable during local development.
+			console.info("Configure code reader", config);
 		});
 		client.onOpen = async () => {
 			await client.send<CompartmentsMessage>({

--- a/packages/cube-app-react-sdk/src/index.tsx
+++ b/packages/cube-app-react-sdk/src/index.tsx
@@ -14,7 +14,7 @@ import {
 import React, {createContext, PropsWithChildren, useContext, useEffect, useMemo, useState} from "react";
 
 // Re-export the types from the SDK to make them available to consumers of the React SDK.
-export type * from "@variocube/cube-app-sdk";
+export * from "@variocube/cube-app-sdk";
 
 export type Locks = Record<string, LockStatus>;
 

--- a/packages/cube-app-react-sdk/src/index.tsx
+++ b/packages/cube-app-react-sdk/src/index.tsx
@@ -13,7 +13,9 @@ import {
 } from "@variocube/cube-app-sdk";
 import React, {createContext, PropsWithChildren, useContext, useEffect, useMemo, useState} from "react";
 
-// Re-export the types from the SDK to make them available to consumers of the React SDK.
+// Re-export everything from the SDK — types as well as runtime values (e.g. `connect`, the
+// `Symbology` enum and `validateBarcodeConfig`) — so consumers of the React SDK can use them
+// without depending on @variocube/cube-app-sdk directly.
 export * from "@variocube/cube-app-sdk";
 
 export type Locks = Record<string, LockStatus>;

--- a/packages/cube-app-react-sdk/src/index.tsx
+++ b/packages/cube-app-react-sdk/src/index.tsx
@@ -13,10 +13,14 @@ import {
 } from "@variocube/cube-app-sdk";
 import React, {createContext, PropsWithChildren, useContext, useEffect, useMemo, useState} from "react";
 
-// Re-export everything from the SDK — types as well as runtime values (e.g. `connect`, the
-// `Symbology` enum and `validateBarcodeConfig`) — so consumers of the React SDK can use them
-// without depending on @variocube/cube-app-sdk directly.
-export * from "@variocube/cube-app-sdk";
+// Re-export the SDK's types via `export type *` so runtime values like `connect` are NOT
+// re-exported — React SDK consumers should use CubeProvider instead of connecting directly.
+// The two runtime values that are genuinely useful (the `Symbology` enum and
+// `validateCodeReaderConfig`) are re-exported explicitly below.
+// `dprint-ignore` because dprint 0.77.0 wrongly strips the `type` from `export type *`.
+// dprint-ignore
+export type * from "@variocube/cube-app-sdk";
+export { Symbology, validateCodeReaderConfig } from "@variocube/cube-app-sdk";
 
 export type Locks = Record<string, LockStatus>;
 

--- a/packages/cube-app-sdk/package.json
+++ b/packages/cube-app-sdk/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "dependencies": {
-    "@variocube/driver-common": "^2.7.1",
+    "@variocube/driver-common": "^2.8.0",
     "@variocube/vcmp": "^2.3.0"
   },
   "files": [

--- a/packages/cube-app-sdk/package.json
+++ b/packages/cube-app-sdk/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "dependencies": {
+    "@variocube/driver-common": "^2.7.1",
     "@variocube/vcmp": "^2.3.0"
   },
   "files": [

--- a/packages/cube-app-sdk/src/cube.ts
+++ b/packages/cube-app-sdk/src/cube.ts
@@ -1,7 +1,10 @@
+import {validateBarcodeConfig} from "@variocube/driver-common";
+import type {BarcodeReaderConfig} from "@variocube/driver-common";
 import {VcmpClient} from "@variocube/vcmp";
 import type {
 	CodeMessage,
 	CompartmentsMessage,
+	ConfigureBarcodeReaderMessage,
 	DevicesMessage,
 	LockMessage,
 	OpenLockMessage,
@@ -128,6 +131,18 @@ export class CubeImpl implements Cube {
 		await this.#client.send<RestartDeviceMessage>({
 			"@type": "restartDevice",
 			deviceId,
+		});
+	}
+
+	async configureBarcodeReader(deviceId: string, config: BarcodeReaderConfig) {
+		const {valid, errors} = validateBarcodeConfig(config);
+		if (!valid) {
+			throw new Error(`Invalid barcode reader configuration: ${errors.join("; ")}`);
+		}
+		await this.#client.send<ConfigureBarcodeReaderMessage>({
+			"@type": "configureBarcodeReader",
+			deviceId,
+			config,
 		});
 	}
 

--- a/packages/cube-app-sdk/src/cube.ts
+++ b/packages/cube-app-sdk/src/cube.ts
@@ -1,4 +1,4 @@
-import {validateBarcodeConfig as validateCodeReaderConfig} from "@variocube/driver-common";
+import {validateBarcodeConfig as validateCodeReaderConfig} from "@variocube/driver-common/barcode-reader/config";
 import {VcmpClient} from "@variocube/vcmp";
 import type {
 	CodeMessage,

--- a/packages/cube-app-sdk/src/cube.ts
+++ b/packages/cube-app-sdk/src/cube.ts
@@ -1,4 +1,4 @@
-import {validateBarcodeConfig} from "@variocube/driver-common";
+import {validateBarcodeConfig as validateCodeReaderConfig} from "@variocube/driver-common";
 import {VcmpClient} from "@variocube/vcmp";
 import type {
 	CodeMessage,
@@ -135,7 +135,7 @@ export class CubeImpl implements Cube {
 	}
 
 	async configureCodeReader(config: CodeReaderConfig) {
-		const {valid, errors} = validateBarcodeConfig(config);
+		const {valid, errors} = validateCodeReaderConfig(config);
 		if (!valid) {
 			throw new Error(`Invalid code reader configuration: ${errors.join("; ")}`);
 		}

--- a/packages/cube-app-sdk/src/cube.ts
+++ b/packages/cube-app-sdk/src/cube.ts
@@ -1,10 +1,9 @@
 import {validateBarcodeConfig} from "@variocube/driver-common";
-import type {BarcodeReaderConfig} from "@variocube/driver-common";
 import {VcmpClient} from "@variocube/vcmp";
 import type {
 	CodeMessage,
 	CompartmentsMessage,
-	ConfigureBarcodeReaderMessage,
+	ConfigureCodeReaderMessage,
 	DevicesMessage,
 	LockMessage,
 	OpenLockMessage,
@@ -14,6 +13,7 @@ import type {
 import type {
 	CloseEvent,
 	CodeEvent,
+	CodeReaderConfig,
 	Compartment,
 	CompartmentsEvent,
 	Cube,
@@ -134,14 +134,13 @@ export class CubeImpl implements Cube {
 		});
 	}
 
-	async configureBarcodeReader(deviceId: string, config: BarcodeReaderConfig) {
+	async configureCodeReader(config: CodeReaderConfig) {
 		const {valid, errors} = validateBarcodeConfig(config);
 		if (!valid) {
-			throw new Error(`Invalid barcode reader configuration: ${errors.join("; ")}`);
+			throw new Error(`Invalid code reader configuration: ${errors.join("; ")}`);
 		}
-		await this.#client.send<ConfigureBarcodeReaderMessage>({
-			"@type": "configureBarcodeReader",
-			deviceId,
+		await this.#client.send<ConfigureCodeReaderMessage>({
+			"@type": "configureCodeReader",
 			config,
 		});
 	}

--- a/packages/cube-app-sdk/src/index.ts
+++ b/packages/cube-app-sdk/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./connect.js";
+// `./messages` and `./types` are type-only modules, so these plain `export *` re-export
+// no runtime values. We don't write `export type *` here because dprint strips the `type`
+// keyword from a star re-export (see the dprint-ignore note in the React SDK's index).
 export * from "./messages";
 export * from "./types";
 

--- a/packages/cube-app-sdk/src/index.ts
+++ b/packages/cube-app-sdk/src/index.ts
@@ -2,11 +2,12 @@ export * from "./connect.js";
 export * from "./messages";
 export * from "./types";
 
-// Re-export the standardized barcode reader configuration so app developers can
-// consume the config types and validation without depending on @variocube/driver-common directly.
-export { Symbology, validateBarcodeConfig } from "@variocube/driver-common";
+// Re-export the standardized code reader configuration so app developers can consume the
+// config types and validation without depending on @variocube/driver-common directly.
+// driver-common names these "barcode reader"; the SDK surfaces them as "code reader" because
+// the device decodes more than linear barcodes. `CodeReaderConfig` is re-exported from ./types.
+export { Symbology, validateBarcodeConfig as validateCodeReaderConfig } from "@variocube/driver-common";
 export type {
-	BarcodeReaderConfig,
 	IndicatorConfig,
 	OutputFormattingConfig,
 	OutputTerminator,

--- a/packages/cube-app-sdk/src/index.ts
+++ b/packages/cube-app-sdk/src/index.ts
@@ -9,7 +9,12 @@ export * from "./types";
 // config types and validation without depending on @variocube/driver-common directly.
 // driver-common names these "barcode reader"; the SDK surfaces them as "code reader" because
 // the device decodes more than linear barcodes. `CodeReaderConfig` is re-exported from ./types.
-export { Symbology, validateBarcodeConfig as validateCodeReaderConfig } from "@variocube/driver-common";
+// Imported from the `barcode-reader/config` subpath, which is dependency-free, so consumers
+// never pull driver-common's Node-only `ws`/`chalk` graph into their bundle.
+export {
+	Symbology,
+	validateBarcodeConfig as validateCodeReaderConfig,
+} from "@variocube/driver-common/barcode-reader/config";
 export type {
 	IndicatorConfig,
 	OutputFormattingConfig,
@@ -17,4 +22,4 @@ export type {
 	ToneConfig,
 	TriggerTimingConfig,
 	ValidationResult,
-} from "@variocube/driver-common";
+} from "@variocube/driver-common/barcode-reader/config";

--- a/packages/cube-app-sdk/src/index.ts
+++ b/packages/cube-app-sdk/src/index.ts
@@ -1,4 +1,16 @@
-
 export * from "./connect.js";
-export type * from "./types";
-export type * from "./messages";
+export * from "./messages";
+export * from "./types";
+
+// Re-export the standardized barcode reader configuration so app developers can
+// consume the config types and validation without depending on @variocube/driver-common directly.
+export { Symbology, validateBarcodeConfig } from "@variocube/driver-common";
+export type {
+	BarcodeReaderConfig,
+	IndicatorConfig,
+	OutputFormattingConfig,
+	OutputTerminator,
+	ToneConfig,
+	TriggerTimingConfig,
+	ValidationResult,
+} from "@variocube/driver-common";

--- a/packages/cube-app-sdk/src/messages.ts
+++ b/packages/cube-app-sdk/src/messages.ts
@@ -1,3 +1,4 @@
+import {BarcodeReaderConfig} from "@variocube/driver-common";
 import {VcmpMessage} from "@variocube/vcmp";
 import {CompartmentsEvent, DevicesEvent, LockEvent} from "./types";
 
@@ -41,4 +42,10 @@ export interface CodeMessage extends VcmpMessage {
 	"@type": "code";
 	code: string;
 	source: "KEYPAD" | "SCANNER" | "NFC";
+}
+
+export interface ConfigureBarcodeReaderMessage extends VcmpMessage {
+	"@type": "configureBarcodeReader";
+	deviceId: string;
+	config: BarcodeReaderConfig;
 }

--- a/packages/cube-app-sdk/src/messages.ts
+++ b/packages/cube-app-sdk/src/messages.ts
@@ -1,6 +1,5 @@
-import {BarcodeReaderConfig} from "@variocube/driver-common";
 import {VcmpMessage} from "@variocube/vcmp";
-import {CompartmentsEvent, DevicesEvent, LockEvent} from "./types";
+import {CodeReaderConfig, CompartmentsEvent, DevicesEvent, LockEvent} from "./types";
 
 export interface OpenLockMessage extends VcmpMessage {
 	"@type": "openLock";
@@ -44,8 +43,7 @@ export interface CodeMessage extends VcmpMessage {
 	source: "KEYPAD" | "SCANNER" | "NFC";
 }
 
-export interface ConfigureBarcodeReaderMessage extends VcmpMessage {
-	"@type": "configureBarcodeReader";
-	deviceId: string;
-	config: BarcodeReaderConfig;
+export interface ConfigureCodeReaderMessage extends VcmpMessage {
+	"@type": "configureCodeReader";
+	config: CodeReaderConfig;
 }

--- a/packages/cube-app-sdk/src/types.ts
+++ b/packages/cube-app-sdk/src/types.ts
@@ -1,5 +1,14 @@
 import type {BarcodeReaderConfig} from "@variocube/driver-common";
 
+/**
+ * Standardized configuration for a code reader.
+ *
+ * Called "code reader" rather than "barcode reader" because the device decodes more than
+ * linear barcodes (QR, DataMatrix, PDF417, Aztec, …). Structurally identical to the
+ * `BarcodeReaderConfig` schema shared with the driver via `@variocube/driver-common`.
+ */
+export type CodeReaderConfig = BarcodeReaderConfig;
+
 /** The status of a lock. */
 export type LockStatus = "OPEN" | "CLOSED" | "BREAKIN" | "BLOCKED";
 
@@ -272,19 +281,20 @@ export interface Cube {
 	restartDevice(deviceId: string): Promise<void>;
 
 	/**
-	 * Pushes a standardized configuration to a connected barcode reader.
+	 * Pushes a standardized configuration to the connected code reader(s).
 	 *
 	 * The config is validated synchronously before sending, using the shared validation
 	 * function from `@variocube/driver-common`. The driver overlays the (possibly partial)
 	 * config on its default vendor profile and applies what the reader supports; in v1 the
 	 * driver's apply-result is log-only, so no structured success/failure ack is returned.
 	 *
-	 * @param deviceId The id of the barcode reader device to configure.
-	 * @param config The standardized barcode reader configuration to apply.
+	 * The config is applied to all connected code readers; there is no per-device targeting.
+	 *
+	 * @param config The standardized code reader configuration to apply.
 	 * @return A promise that resolves when the config was successfully passed to the service.
 	 * @throws Error if the config fails validation, or if the message could not be passed to the service.
 	 */
-	configureBarcodeReader(deviceId: string, config: BarcodeReaderConfig): Promise<void>;
+	configureCodeReader(config: CodeReaderConfig): Promise<void>;
 
 	/**
 	 * Closes the connection to the cube app service.

--- a/packages/cube-app-sdk/src/types.ts
+++ b/packages/cube-app-sdk/src/types.ts
@@ -1,4 +1,4 @@
-import type {BarcodeReaderConfig} from "@variocube/driver-common";
+import type {BarcodeReaderConfig} from "@variocube/driver-common/barcode-reader/config";
 
 /**
  * Standardized configuration for a code reader.

--- a/packages/cube-app-sdk/src/types.ts
+++ b/packages/cube-app-sdk/src/types.ts
@@ -1,3 +1,5 @@
+import type {BarcodeReaderConfig} from "@variocube/driver-common";
+
 /** The status of a lock. */
 export type LockStatus = "OPEN" | "CLOSED" | "BREAKIN" | "BLOCKED";
 
@@ -268,6 +270,21 @@ export interface Cube {
 	 * @throws Error if the restart command could not be passed to the service.
 	 */
 	restartDevice(deviceId: string): Promise<void>;
+
+	/**
+	 * Pushes a standardized configuration to a connected barcode reader.
+	 *
+	 * The config is validated synchronously before sending, using the shared validation
+	 * function from `@variocube/driver-common`. The driver overlays the (possibly partial)
+	 * config on its default vendor profile and applies what the reader supports; in v1 the
+	 * driver's apply-result is log-only, so no structured success/failure ack is returned.
+	 *
+	 * @param deviceId The id of the barcode reader device to configure.
+	 * @param config The standardized barcode reader configuration to apply.
+	 * @return A promise that resolves when the config was successfully passed to the service.
+	 * @throws Error if the config fails validation, or if the message could not be passed to the service.
+	 */
+	configureBarcodeReader(deviceId: string, config: BarcodeReaderConfig): Promise<void>;
 
 	/**
 	 * Closes the connection to the cube app service.

--- a/packages/cube-app-service/package.json
+++ b/packages/cube-app-service/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "devDependencies": {
     "@variocube/cube-app-mock": "^1.1.0",
-    "@variocube/driver-common": "^2.7.1",
+    "@variocube/driver-common": "^2.8.0",
     "@variocube/vcmp-server": "^2.4.0",
     "dotenv": "^16.5.0",
     "yargs": "^17.7.2"

--- a/packages/cube-app-service/package.json
+++ b/packages/cube-app-service/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "devDependencies": {
     "@variocube/cube-app-mock": "^1.1.0",
-    "@variocube/driver-common": "^2.2.0",
+    "@variocube/driver-common": "^2.7.1",
     "@variocube/vcmp-server": "^2.4.0",
     "dotenv": "^16.5.0",
     "yargs": "^17.7.2"

--- a/packages/cube-app-service/src/server.ts
+++ b/packages/cube-app-service/src/server.ts
@@ -1,7 +1,7 @@
 import {
 	CodeMessage,
 	CompartmentsMessage,
-	ConfigureBarcodeReaderMessage,
+	ConfigureCodeReaderMessage,
 	DevicesMessage,
 	LockMessage,
 	LockStatus,
@@ -144,8 +144,8 @@ export class Server {
 			log.info(`Restart device`, message);
 			await this.sendToLocker(message);
 		});
-		this.#appServer.on<ConfigureBarcodeReaderMessage>("configureBarcodeReader", async (message) => {
-			log.info(`Configure barcode reader`, message);
+		this.#appServer.on<ConfigureCodeReaderMessage>("configureCodeReader", async (message) => {
+			log.info(`Configure code reader`, message);
 			await this.sendToLocker(message);
 		});
 

--- a/packages/cube-app-service/src/server.ts
+++ b/packages/cube-app-service/src/server.ts
@@ -1,6 +1,7 @@
 import {
 	CodeMessage,
 	CompartmentsMessage,
+	ConfigureBarcodeReaderMessage,
 	DevicesMessage,
 	LockMessage,
 	LockStatus,
@@ -141,6 +142,10 @@ export class Server {
 		});
 		this.#appServer.on<RestartDeviceMessage>("restartDevice", async (message) => {
 			log.info(`Restart device`, message);
+			await this.sendToLocker(message);
+		});
+		this.#appServer.on<ConfigureBarcodeReaderMessage>("configureBarcodeReader", async (message) => {
+			log.info(`Configure barcode reader`, message);
 			await this.sendToLocker(message);
 		});
 


### PR DESCRIPTION
## Summary

Adds a `configureCodeReader(config)` method to the Cube-App-SDK that lets app developers push a standardized config to the connected code reader(s).

- **New SDK method** accepting the standardized config (symbologies, indicators, trigger & timing, output formatting), typed as `CodeReaderConfig`.
- **Validates the payload before sending** using the shared validator from `@variocube/driver-common` — the single source of truth shared with the driver. Validation errors are surfaced **synchronously** (the method throws with the joined error list).
- **Sends the validated payload through to the driver** via a `configureCodeReader` VCMP message; `cube-app-service` relays it to the controller/mock like the existing `restartDevice` pass-through. The dev mock logs the received config so the pass-through is observable during local development.
- The driver's apply-result is **log-only in v1** — no structured ack yet.

### Naming & API surface
- Surfaced as **`CodeReader`** rather than `BarcodeReader`: the device decodes more than linear barcodes (QR, DataMatrix, PDF417, Aztec, …). `@variocube/driver-common` keeps its `Barcode*` names internally; the SDK re-exports them as `CodeReaderConfig` (alias of `BarcodeReaderConfig`) and `validateCodeReaderConfig`. The wire-level `DeviceType "BarcodeReader"` is unchanged.
- **No `deviceId`**: the controller applies the config to all connected code readers, with no per-device targeting (variocube/controller#126).
- The `Symbology` enum and `CodeReaderConfig` / `validateCodeReaderConfig` are re-exported from the SDK so app developers need no direct `@variocube/driver-common` dependency. The React SDK re-exports the SDK's types via `export type *` and explicitly re-exports the two runtime values (`Symbology`, `validateCodeReaderConfig`), so these flow through to React consumers too.

### Dependency & bundling
- `@variocube/driver-common` is now a **runtime dependency** (`^2.8.0`) of `cube-app-sdk`, since the validator and `Symbology` are used at runtime (and a devDependency of `cube-app-service`).
- The validator, `Symbology`, and the config types are imported from the dependency-free **`@variocube/driver-common/barcode-reader/config`** subpath (added in driver-common 2.8.0), not the package root. The root transitively pulls driver-common's Node-only `ws`/`chalk` graph; the subpath maps straight to the pure config module, so this browser-targeted SDK never drags those into a consumer's bundle.

### Related driver-common work (merged & released as 2.8.0)
- variocube/driver-common#6 — config schema, validation, and Configure hook (Part A of variocube/drivers#16).
- variocube/driver-common#8 — `sideEffects: false` + the pure `barcode-reader/config` subpath export.

## Out of scope (tracked separately)
- Controller pass-through — variocube/controller#126.
- Per-property apply feedback from the driver — v1 logs only.

## Test plan
- [x] `npm run build` — all 5 packages build cleanly.
- [x] `npx dprint check` — formatting clean.
- [x] Generated declarations expose `configureCodeReader(config: CodeReaderConfig)` and the re-exports; no `Barcode`/`deviceId` leaks into the configure surface.
- [x] Verified the `barcode-reader/config` subpath resolves under the SDK's `moduleResolution: Bundler` and pulls **no** `ws`/`chalk` into the build output.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
