### PR TITLE
ci: publish on GitHub Release, keep repo versions at 0.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  release:
+    types: [published]
 permissions:
   id-token: write  # Required for OIDC
   contents: write
@@ -14,21 +19,34 @@ jobs:
         registry-url: https://registry.npmjs.org
         scope: '@variocube'
     - run: npm ci
+
+    # On a GitHub Release, stamp the version from the release tag into every
+    # package (the repo itself stays at 0.0.0). Tag may be `1.2.3` or `v1.2.3`.
+    - if: github.event_name == 'release'
+      run: |
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION#v}"
+        # The release event checks out a detached HEAD; put it on a throwaway
+        # branch so lerna is happy. Nothing is committed or pushed.
+        git checkout -B release-build
+        npx lerna version "$VERSION" --no-git-tag-version --no-push --force-publish --yes
+
     - run: npm run build
     - run: npm run test
-    - if: startsWith(github.ref, 'refs/tags/')
-      run: npx lerna publish from-git --yes --no-private
+
+    - if: github.event_name == 'release'
+      run: npx lerna publish from-package --yes --no-private
 
     - run: ./build_debian.sh
 
-    - if: startsWith(github.ref, 'refs/tags/')
+    - if: github.event_name == 'release'
       run: |
         aws s3 cp --region eu-west-1 dpkg/ s3://og-repository/packages/ --recursive --exclude "*" --include "variocube-cube-app-service_*.deb"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - if: startsWith(github.ref, 'refs/tags/')
+    - if: github.event_name == 'release'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: ./packages/cube-app-demo/dist # The folder the action should deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,12 @@ Currently no unit tests are configured. The test script is a placeholder.
 
 ## Publishing
 
-Publishing is handled automatically by CI when a tag is pushed:
+Releases are cut by creating a **GitHub Release**; CI does the rest. The versions committed in the
+repo stay at `0.0.0` — the published version comes from the release tag.
 
-1. Run `./release.sh` which invokes `lerna version`
-2. Push the tag
-3. CI publishes to npm under `@variocube` scope
+1. Create the release: `./release.sh <version>` (wraps `gh release create <version> --target main --generate-notes`), or create it from the GitHub UI. Tags may be `1.3.0` or `v1.3.0`.
+2. The `release: published` event triggers CI, which:
+   - stamps the tag's version into every package via `lerna version --no-git-tag-version`,
+   - publishes the public packages to npm (`lerna publish from-package`) under `@variocube`,
+   - builds the `cube-app-service` `.deb` and uploads it to the apt repository,
+   - deploys the demo to GitHub Pages.

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11003,27 +11003,27 @@
     },
     "packages/cube-app-demo": {
       "name": "@variocube/cube-app-demo",
-      "version": "1.2.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@variocube/cube-app-react-sdk": "^1.2.0",
-        "@variocube/cube-app-sdk": "^1.2.0"
+        "@variocube/cube-app-react-sdk": "^0.0.0",
+        "@variocube/cube-app-sdk": "^0.0.0"
       }
     },
     "packages/cube-app-mock": {
       "name": "@variocube/cube-app-mock",
-      "version": "1.2.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@variocube/cube-app-sdk": "^1.2.0"
+        "@variocube/cube-app-sdk": "^0.0.0"
       }
     },
     "packages/cube-app-react-sdk": {
       "name": "@variocube/cube-app-react-sdk",
-      "version": "1.2.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@variocube/cube-app-sdk": "^1.2.0"
+        "@variocube/cube-app-sdk": "^0.0.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -11031,7 +11031,7 @@
     },
     "packages/cube-app-sdk": {
       "name": "@variocube/cube-app-sdk",
-      "version": "1.2.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@variocube/driver-common": "^2.8.0",
@@ -11040,13 +11040,13 @@
     },
     "packages/cube-app-service": {
       "name": "@variocube/cube-app-service",
-      "version": "1.2.0",
+      "version": "0.0.0",
       "license": "MIT",
       "bin": {
         "cube-app-service": "dist/main.mjs"
       },
       "devDependencies": {
-        "@variocube/cube-app-mock": "^1.2.0",
+        "@variocube/cube-app-mock": "^0.0.0",
         "@variocube/driver-common": "^2.8.0",
         "@variocube/vcmp-server": "^2.4.0",
         "dotenv": "^16.5.0",

--- a/packages/cube-app-demo/package.json
+++ b/packages/cube-app-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@variocube/cube-app-demo",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "Demo application showcasing the Cube App SDK",
   "main": "esm/index.js",
   "private": true,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "devDependencies": {
-    "@variocube/cube-app-react-sdk": "^1.2.0",
-    "@variocube/cube-app-sdk": "^1.2.0"
+    "@variocube/cube-app-react-sdk": "^0.0.0",
+    "@variocube/cube-app-sdk": "^0.0.0"
   }
 }

--- a/packages/cube-app-mock/package.json
+++ b/packages/cube-app-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@variocube/cube-app-mock",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "Mock UI for the Variocube Cube-App SDK",
   "main": "dist/index.js",
   "private": true,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "devDependencies": {
-    "@variocube/cube-app-sdk": "^1.2.0"
+    "@variocube/cube-app-sdk": "^0.0.0"
   },
   "files": [
     "dist/**"

--- a/packages/cube-app-react-sdk/package.json
+++ b/packages/cube-app-react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@variocube/cube-app-react-sdk",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "SDK for developing React apps that run on Variocube lockers",
   "main": "esm/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "dependencies": {
-    "@variocube/cube-app-sdk": "^1.2.0"
+    "@variocube/cube-app-sdk": "^0.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/cube-app-sdk/package.json
+++ b/packages/cube-app-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@variocube/cube-app-sdk",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "SDK for developing apps that run on Variocube lockers.",
   "main": "esm/index.js",
   "type": "module",

--- a/packages/cube-app-service/package.json
+++ b/packages/cube-app-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@variocube/cube-app-service",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "Gateway service that connects the cube-app-sdk to Variocube locker services.",
   "main": "dist/main.mjs",
   "type": "module",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/variocube/cube-app-sdk#readme",
   "devDependencies": {
-    "@variocube/cube-app-mock": "^1.2.0",
+    "@variocube/cube-app-mock": "^0.0.0",
     "@variocube/driver-common": "^2.8.0",
     "@variocube/vcmp-server": "^2.4.0",
     "dotenv": "^16.5.0",

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
 
-npx lerna version
+set -e
+
+# Releases are cut by creating a GitHub Release. CI (.github/workflows/ci.yml)
+# then stamps the tag's version into every package and publishes the npm + deb
+# artifacts. The versions committed in the repo stay at 0.0.0.
+#
+# Usage: ./release.sh <version>   e.g. ./release.sh 1.3.0
+
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+	echo "Usage: ./release.sh <version>   (e.g. 1.3.0)" >&2
+	exit 1
+fi
+
+gh release create "$VERSION" --target main --generate-notes


### PR DESCRIPTION
## Summary

Switches release management from tag-pushed `lerna version` to **GitHub Releases**. Creating a GitHub Release now triggers publication of the npm and deb packages; the version is taken from the release tag and stamped into the packages at build time, so the versions committed in the repo stay at `0.0.0`.

## Changes

- **`.github/workflows/ci.yml`**
  - Trigger on `release: published` (plus branch pushes and PRs for ordinary CI). Push trigger is now branch-scoped so the tag a release creates no longer double-fires the workflow.
  - Publish/S3-upload/Pages-deploy steps now gate on `github.event_name == 'release'` instead of `startsWith(github.ref, 'refs/tags/')`.
  - On release, stamp the tag version into every package with `lerna version <ver> --no-git-tag-version --no-push --force-publish` (tag may be `1.2.3` or `v1.2.3`), then publish with `lerna publish from-package`.
- **Versions → `0.0.0`**: `lerna.json` and all five package `version` fields set to `0.0.0`; internal `@variocube/cube-app-*` dependency ranges pinned to `^0.0.0` so npm workspaces still resolve them locally. External `@variocube` deps (driver-common, vcmp, vcmp-server) are untouched.
- **`release.sh`**: now wraps `gh release create <version> --target main --generate-notes` (takes the version as an argument) instead of running `lerna version`.
- **`CLAUDE.md`**: documents the new publishing flow.

This aligns the repo with the workspace-wide `gh release` release convention.

## How to cut a release

```bash
./release.sh 1.3.0   # or create the Release from the GitHub UI
```

## Verification

- `npm install` keeps the workspace symlinks resolving locally at `^0.0.0`.
- `npm run build` ✅, `npx dprint check` ✅.
- Verified the stamping step locally on a simulated detached-HEAD checkout: `0.0.0 → 9.9.9` across all packages, with internal dep ranges rewritten to `^9.9.9` and external `@variocube` deps left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)